### PR TITLE
Fix Codeforces contest links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The challenge consists of 5 tasks with increasing complexity. Each one focuses o
 
 
 2. **Register for the Tact Smart Battle challenge**
-    - After logging in, visit the official challenge page on [Codeforces](https://codeforces.com/contests/2105) ([Registration guide](registration.md)).
+    - After logging in, visit the official challenge page on [Codeforces](https://codeforces.com/contest/2105) ([Registration guide](registration.md)).
     - Complete the registration form.
     - Be sure to enter your:
         - **Telegram username** — for community contact and support
@@ -224,7 +224,7 @@ Top 128 participants will receive Toncoin prizes and SBTs (Soulbound Tokens).
 
 ## 📅 Timeline
 
-- 📝 Registration: [codeforces.com/register](https://codeforces.com/contests/2105)
+ - 📝 Registration: [codeforces.com/register](https://codeforces.com/contest/2105)
 - 🚀 Challenge is open now
 - 🛑 Final Submission Deadline: **April 28, 12:00 (UTC+3)**
 

--- a/registration.md
+++ b/registration.md
@@ -5,7 +5,7 @@
 ---
 
 ### 🔹 Step 1. Go to the registration page
-👉 [https://codeforces.com/contests/2105](https://codeforces.com/contests/2105)
+👉 [https://codeforces.com/contest/2105](https://codeforces.com/contest/2105)
 
  <img src=images/registration1.png width="600"/>
 
@@ -33,7 +33,7 @@
 ---
 
 ### 🔹 Step 3. Complete your registration
-Go back to the [contest page](https://codeforces.com/contests/2105) and click **Register** again
+Go back to the [contest page](https://codeforces.com/contest/2105) and click **Register** again
 
 <img src=images/registration3.png width="600"/>
 


### PR DESCRIPTION
## Summary
- correct contest page links in README and registration instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68414959b2c48333a0e93a7bf5e48506